### PR TITLE
0.3.1 bugfix release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.1 2014-02-25
+- bugfix: `itlmdir` param is not used anywhere and also causes compilation to fail
+- bugfix: default value for `agenttemppath` param is incorrect
+
 ## 0.3.0 2014-02-13
 - feature: apparently we do not love the `agentenable` parameter
 

--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name    'huit/ilmt'
-version '0.3.0'
+version '0.3.1'
 source 'UNKNOWN'
 author 'huit'
 license 'MIT License'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -53,7 +53,6 @@ class ilmt (
   $citinstallpath = $ilmt::params::citinstallpath,
   $fipsenabled = $ilmt::params::fipsenabled,
   $installservercertificate = $ilmt::params::installservercertificate,
-  $itlmdir = $itlm::params::itlmdir,
   $messagehandleraddress = $ilmt::params::messagehandleraddress,
   $package = $ilmt::params::package,
   $port = $ilmt::params::port,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,7 +5,7 @@ class ilmt::params {
   $ensure = 'present'
   $agentcert = false
   $agentcertfilepath = ''
-  $agenttemppath = '/tmp/itlm'
+  $agenttemppath = '/tmp/ilmt'
   $citinstallpath = ''
   $fipsenabled = 'n'
   $installservercertificate = 'n'

--- a/spec/classes/ilmt_spec.rb
+++ b/spec/classes/ilmt_spec.rb
@@ -12,6 +12,16 @@ describe 'ilmt', :type => :class do
   describe 'on RedHat platform' do
     let(:facts) { { :osfamily => 'RedHat' } }
 
+    describe 'fails to compile with itlmdir param' do
+      let(:params) { {
+        :package => 'PACKAGE_URI',
+        :itlmdir => '/opt/itlm',
+      } }
+      it {
+        expect { should raise_error(Puppet::Error) }
+      }
+    end
+
     it { should contain_file('response_file').with( {
       :ensure => 'present',
       :path   => '/etc/response_file.txt',


### PR DESCRIPTION
- removing needless and misspelled itlmdir param
- fixing incorrect default for agenttemppath param

Fixes #8
